### PR TITLE
Old snapshots cleanup.

### DIFF
--- a/zookeeper-3.4/Dockerfile
+++ b/zookeeper-3.4/Dockerfile
@@ -14,6 +14,7 @@ RUN mkdir -p /opt
 
 RUN wget -q -O - http://apache.mirrors.pair.com/zookeeper/zookeeper-$ZOOKEEPER_VERSION/zookeeper-$ZOOKEEPER_VERSION.tar.gz | tar -xzf - -C /opt \
     && mv /opt/zookeeper-$ZOOKEEPER_VERSION /opt/zookeeper \
+    && sed -i '/dataDir/d' /opt/zookeeper/conf/zoo_sample.cfg \
     && cp /opt/zookeeper/conf/zoo_sample.cfg /opt/zookeeper/conf/zoo.cfg \
     && mkdir -p /tmp/zookeeper
 
@@ -24,6 +25,7 @@ EXPOSE 2181 2888 3888
 COPY zk_config.sh /usr/local/bin/
 COPY zk_launch.sh /usr/local/bin/
 COPY setacl.sh /usr/local/bin/
+COPY zk_clean_job.sh /usr/local/bin/
 
 WORKDIR /opt/zookeeper
 

--- a/zookeeper-3.4/zk_clean_job.sh
+++ b/zookeeper-3.4/zk_clean_job.sh
@@ -2,13 +2,12 @@
 
 ADDED="$(crontab -l | grep zkCleanup.sh | wc -l)"
 
-if [ "$ADDEDD" != "0" ]; then
+if [ "$ADDED" != "0" ]; then
 	exit;
 fi
 
 # workaround for zkCleanup.sh. We need cleanup only snapshots /var/lib/zookeper
 sed -i '/ZOODATALOGDIR/ s/^/#/' /opt/zookeeper/bin/zkCleanup.sh
-
 # Daily cleanup. After cleanup will remain only 3 last snapshots
 crontab -l | { cat; echo "0	0	*	*	*	/opt/zookeeper/bin/zkCleanup.sh -n 3"; echo ; } | crontab -
 

--- a/zookeeper-3.4/zk_clean_job.sh
+++ b/zookeeper-3.4/zk_clean_job.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+ADDED="$(crontab -l | grep zkCleanup.sh | wc -l)"
+
+if [ "$ADDEDD" != "0" ]; then
+	exit;
+fi
+
+# workaround for zkCleanup.sh. We need cleanup only snapshots /var/lib/zookeper
+sed -i '/ZOODATALOGDIR/ s/^/#/' /opt/zookeeper/bin/zkCleanup.sh
+
+# Daily cleanup. After cleanup will remain only 3 last snapshots
+crontab -l | { cat; echo "0	0	*	*	*	/opt/zookeeper/bin/zkCleanup.sh -n 3"; echo ; } | crontab -
+
+/usr/sbin/crond&

--- a/zookeeper-3.4/zk_config.sh
+++ b/zookeeper-3.4/zk_config.sh
@@ -7,6 +7,10 @@
 set -e 
 set -x 
 
+
+# Add job to crontab for cleaning snapshots
+/usr/local/bin/zk_clean_job.sh&
+
 #This is the Zookeeper ID for the node.
 # Supply if more than one node in the cluster
 export ZK_ID=${ZK_ID:-1}


### PR DESCRIPTION
From zookeeper [docs](http://zookeeper.apache.org/doc/r3.1.2/zookeeperAdmin.html#Ongoing+Data+Directory+Cleanup)

> A ZooKeeper server **will not remove old snapshots and log files**

Old log files will be [logrotated](https://github.com/CiscoCloud/microservices-infrastructure/blob/master/roles/logrotate/files/zookeeper). 
So we need remove old snapshots. In our case Exhibitor cannot do that because of it runs in separate container (as we can [see](https://github.com/Netflix/exhibitor/blob/6d6fee639ac72a0a17423453eaa267769150f16b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/processes/StandardProcessOperations.java#L66) it need to have access to zookeeper install dir).

But also this can be done with default zookeeper script for cleanup `zkCleanup.sh` (periodically from crontab).
In this case we have an issue:
In default /opt/zookeeper/conf/zoo_sample.cfg we have `dataDir=/tmp/zookeeper`. After `zk_launch.sh`  runs it append new dataDir in zoo.cfg but old one will remain. So if we run zkCleanup.sh, script will receive 3 directories (/var/lib/zookeeper, /tmp/zookeeper, /var/log/zookeeper) instead of 2. 
To fix this we'll remove `dataDir=/tmp/zookeeper` from  /opt/zookeeper/conf/zoo_sample.cfg and comment `ZOODATALOGDIR` variable in `zkCleanup.sh` so we can run this script only for `/var/lib/zookeeper` folder.
